### PR TITLE
feat: add manifest generation and publish Dockerfile configs to GitHub Pages

### DIFF
--- a/Dockerfile/build.py
+++ b/Dockerfile/build.py
@@ -173,7 +173,7 @@ def create_manifest(builds: List[Tuple[str, str]] = None) -> Result[str, str]:
         with open(manifest_path, 'w', encoding='utf-8') as f:
             json.dump(manifest, f, indent=4, ensure_ascii=False)
 
-        return Ok(f"Manifest created successfully at {manifest_path} with {len([tag for name_dict in manifest.values() for tag in name_dict])} configurations")
+        return Ok(f"Manifest created successfully at {manifest_path} with {sum(len(tags) for tags in manifest.values())} configurations")
 
     except Exception as e:
         return Err(f"Failed to create manifest: {str(e)}")

--- a/Dockerfile/build.py
+++ b/Dockerfile/build.py
@@ -5,7 +5,28 @@ import json
 import shutil
 from typing import List, Tuple
 
-from utils import discover_builds
+from utils import discover_builds, get_project_root
+
+def get_domain() -> str:
+    """
+    Read domain from /dist/CNAME file. If reading fails, return default domain.
+
+    Returns:
+        str: The domain to use for config URLs
+    """
+    default_domain = "app-server.endkind.cloud"
+    cname_path = get_project_root("dist", "CNAME")
+
+    try:
+        if os.path.exists(cname_path):
+            with open(cname_path, 'r', encoding='utf-8') as f:
+                domain = f.read().strip()
+                if domain:
+                    return domain
+    except Exception as e:
+        print(f"Warning: Could not read domain from {cname_path}: {e}")
+
+    return default_domain
 
 def main():
     build_all()
@@ -82,7 +103,6 @@ def build_all(builds: List[Tuple[str, str]] = discover_builds()) -> None:
 
     print(f"Build complete: {success_count}/{len(builds)} succeeded")
 
-    # Create manifest only with successful builds
     if successful_builds:
         print("\nCreating manifest with successful builds...")
         manifest_result = create_manifest(successful_builds)
@@ -114,7 +134,7 @@ def create_manifest(builds: List[Tuple[str, str]] = None) -> Result[str, str]:
         manifest = {}
 
         for name, tag in builds:
-            config_path = f"./{name}/{tag}/config.json"
+            config_path = os.path.join(os.path.dirname(__file__), name, tag, "config.json")
 
             if not os.path.exists(config_path):
                 print(f"Warning: Config file not found for {name}:{tag}")
@@ -127,15 +147,11 @@ def create_manifest(builds: List[Tuple[str, str]] = None) -> Result[str, str]:
                 if name not in manifest:
                     manifest[name] = {}
 
+                domain = get_domain()
                 manifest_entry = {
-                    "config": f"https://app-server.endkind.cloud/Dockerfile/{name}/{tag}/config.json"
+                    "config": f"https://{domain}/Dockerfile/{name}/{tag}/config.json",
+                    "end_of_life": config.get('end_of_life')
                 }
-
-                end_of_life = config.get('end_of_life')
-                if end_of_life:
-                    manifest_entry["end_of_life"] = end_of_life
-                else:
-                    manifest_entry["end_of_life"] = None
 
                 manifest[name][tag] = manifest_entry
 
@@ -143,19 +159,17 @@ def create_manifest(builds: List[Tuple[str, str]] = None) -> Result[str, str]:
                 print(f"Warning: Could not process config for {name}:{tag}: {e}")
                 continue
 
-        # Copy config files to project root dist directory
         for name, tag in builds:
-            config_path = f"./{name}/{tag}/config.json"
+            config_path = os.path.join(os.path.dirname(__file__), name, tag, "config.json")
             if os.path.exists(config_path):
-                dist_config_dir = f"../dist/Dockerfile/{name}/{tag}"
+                dist_config_dir = get_project_root("dist", "Dockerfile", name, tag)
                 os.makedirs(dist_config_dir, exist_ok=True)
 
-                dist_config_path = f"{dist_config_dir}/config.json"
+                dist_config_path = os.path.join(dist_config_dir, "config.json")
                 shutil.copy2(config_path, dist_config_path)
                 print(f"Copied config: {config_path} -> {dist_config_path}")
 
-        # Write manifest to project root dist directory
-        manifest_path = "../dist/Dockerfile/manifest.json"
+        manifest_path = get_project_root("dist", "Dockerfile", "manifest.json")
         with open(manifest_path, 'w', encoding='utf-8') as f:
             json.dump(manifest, f, indent=4, ensure_ascii=False)
 

--- a/Dockerfile/build.py
+++ b/Dockerfile/build.py
@@ -155,19 +155,16 @@ def create_manifest(builds: List[Tuple[str, str]] = None) -> Result[str, str]:
 
                 manifest[name][tag] = manifest_entry
 
-            except (json.JSONDecodeError, Exception) as e:
-                print(f"Warning: Could not process config for {name}:{tag}: {e}")
-                continue
-
-        for name, tag in builds:
-            config_path = os.path.join(os.path.dirname(__file__), name, tag, "config.json")
-            if os.path.exists(config_path):
                 dist_config_dir = get_project_root("dist", "Dockerfile", name, tag)
                 os.makedirs(dist_config_dir, exist_ok=True)
 
                 dist_config_path = os.path.join(dist_config_dir, "config.json")
                 shutil.copy2(config_path, dist_config_path)
                 print(f"Copied config: {config_path} -> {dist_config_path}")
+
+            except (json.JSONDecodeError, Exception) as e:
+                print(f"Warning: Could not process config for {name}:{tag}: {e}")
+                continue
 
         manifest_path = get_project_root("dist", "Dockerfile", "manifest.json")
         with open(manifest_path, 'w', encoding='utf-8') as f:

--- a/Dockerfile/push.py
+++ b/Dockerfile/push.py
@@ -1,5 +1,7 @@
 from result import Ok, Err, Result, is_ok, is_err
 import subprocess
+import json
+import os
 from typing import List, Tuple
 
 from utils import discover_builds
@@ -41,16 +43,48 @@ ch
     except Exception as e:
         return Err(f"Unexpected error: {str(e)}")
 
-def push_all(builds: List[Tuple[str, str]] = discover_builds()) -> None:
+def get_successful_builds_from_manifest() -> List[Tuple[str, str]]:
     """
-    Push all available Docker images by auto-discovering available configurations.
+    Read the manifest.json to get only successfully built images.
+
+    Returns:
+        List[Tuple[str, str]]: List of (name, tag) tuples from the manifest
     """
+    manifest_path = "../dist/Dockerfile/manifest.json"
+
+    if not os.path.exists(manifest_path):
+        print(f"Warning: Manifest file not found at {manifest_path}")
+        print("Falling back to auto-discovery...")
+        return discover_builds()
+
+    try:
+        with open(manifest_path, 'r', encoding='utf-8') as f:
+            manifest = json.load(f)
+
+        builds = []
+        for name, tags_dict in manifest.items():
+            for tag in tags_dict.keys():
+                builds.append((name, tag))
+
+        return builds
+
+    except (json.JSONDecodeError, Exception) as e:
+        print(f"Warning: Could not read manifest: {e}")
+        print("Falling back to auto-discovery...")
+        return discover_builds()
+
+def push_all(builds: List[Tuple[str, str]] = None) -> None:
+    """
+    Push Docker images based on successful builds from manifest.
+    """
+    if builds is None:
+        builds = get_successful_builds_from_manifest()
 
     if not builds:
-        print("No build configurations found!")
+        print("No successful builds found to push!")
         return
 
-    print(f"Found {len(builds)} build configurations:")
+    print(f"Found {len(builds)} successfully built configurations:")
     for name, tag in builds:
         print(f"  - {name}:{tag}")
 

--- a/Dockerfile/push.py
+++ b/Dockerfile/push.py
@@ -50,7 +50,7 @@ def get_successful_builds_from_manifest() -> List[Tuple[str, str]]:
     Returns:
         List[Tuple[str, str]]: List of (name, tag) tuples from the manifest
     """
-    manifest_path = "../dist/Dockerfile/manifest.json"
+    manifest_path = os.path.join(os.path.dirname(__file__), "..", "dist", "Dockerfile", "manifest.json")
 
     if not os.path.exists(manifest_path):
         print(f"Warning: Manifest file not found at {manifest_path}")

--- a/Dockerfile/push.py
+++ b/Dockerfile/push.py
@@ -4,7 +4,7 @@ import json
 import os
 from typing import List, Tuple
 
-from utils import discover_builds
+from utils import discover_builds, get_project_root
 
 def main():
     push_all()
@@ -50,7 +50,7 @@ def get_successful_builds_from_manifest() -> List[Tuple[str, str]]:
     Returns:
         List[Tuple[str, str]]: List of (name, tag) tuples from the manifest
     """
-    manifest_path = os.path.join(os.path.dirname(__file__), "..", "dist", "Dockerfile", "manifest.json")
+    manifest_path = get_project_root("dist", "Dockerfile", "manifest.json")
 
     if not os.path.exists(manifest_path):
         print(f"Warning: Manifest file not found at {manifest_path}")

--- a/Dockerfile/utils.py
+++ b/Dockerfile/utils.py
@@ -4,6 +4,31 @@ from datetime import datetime, date
 from typing import List, Tuple
 
 
+def get_project_root(*paths: str) -> str:
+    """
+    Get the project root path and optionally join additional paths.
+    Since the Python files are located in the 'Dockerfile/' subdirectory,
+    this function navigates up to find the project root.
+
+    Args:
+        *paths: Optional path components to join with the project root
+
+    Returns:
+        str: The project root path, optionally joined with additional paths
+    """
+    # Get the directory of this utils.py file (which is in Dockerfile/)
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+
+    # Navigate up one level to get to the project root
+    project_root = os.path.dirname(current_dir)
+
+    # Join with optional additional paths
+    if paths:
+        return os.path.join(project_root, *paths)
+
+    return project_root
+
+
 def discover_builds() -> List[Tuple[str, str]]:
     """
     Automatically discover available build configurations by scanning directories.

--- a/dist/CNAME
+++ b/dist/CNAME
@@ -1,0 +1,1 @@
+app-server.endkind.cloud

--- a/dist/Dockerfile/.gitignore
+++ b/dist/Dockerfile/.gitignore
@@ -1,0 +1,2 @@
+config.json
+manifest.json

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,6 @@
+# App Server Template
+
+## Dockerfile
+
+- [README](https://github.com/EnderHostingHQ/App-Server-Template/blob/master/Dockerfile/python/README.md)
+- [Manifest](./Dockerfile/manifest.json)


### PR DESCRIPTION
- feat: generate manifest.json from successful builds and export to dist/Dockerfile
- feat: read successful builds from manifest in push workflow
- documentation: add dist/README linking Dockerfile README and manifest
- maintenance: add GitHub Pages CNAME (app-server.endkind.cloud)
- maintenance: add dist/Dockerfile/.gitignore to exclude generated config.json and manifest.json