### PR TITLE
fix: add GitHub Pages deployment to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,14 @@ jobs:
           cd Dockerfile
           source .venv/bin/activate
           python push.py
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Release static version for ${{ github.ref }} [skip ci]'
+          keep_files: false
+          publish_branch: gh-pages


### PR DESCRIPTION
- fix: deploy gh-pages from release workflow using peaceiris/actions-gh-pages (publish ./dist to gh-pages)