### PR TITLE
fix: publish all assets to gh-pages by removing .gitignore from dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,10 @@ jobs:
           source .venv/bin/activate
           python push.py
 
+      - name: Prepare dist directory for deployment
+        run: |
+          find ./dist -name ".gitignore" -type f -delete
+
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
- fix: remove '.gitignore' files from dist before gh-pages deploy to ensure all assets are published (release.yml)