### PR TITLE
fix: use version-scoped venv to prevent errors after Python upgrades

### DIFF
--- a/Dockerfile/python/3.10-slim/entrypoint.sh
+++ b/Dockerfile/python/3.10-slim/entrypoint.sh
@@ -4,15 +4,19 @@ set -euo pipefail
 if [ -f "requirements.txt" ]; then
     echo "Initializing Python environment..."
 
-    if [ ! -d ".venv" ]; then
-        echo "Creating virtual environment..."
-        python3 -m venv .venv || { echo "Failed to create virtual environment"; exit 1; }
+    # Get Python version for venv directory naming
+    PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')")
+    VENV_DIR=".venv-${PYTHON_VERSION}"
+
+    if [ ! -d "$VENV_DIR" ]; then
+        echo "Creating virtual environment for Python ${PYTHON_VERSION}..."
+        python3 -m venv "$VENV_DIR" || { echo "Failed to create virtual environment"; exit 1; }
     fi
 
-    . .venv/bin/activate || { echo "Failed to activate virtual environment"; exit 1; }
+    . "$VENV_DIR/bin/activate" || { echo "Failed to activate virtual environment"; exit 1; }
 
     CURRENT_HASH=$(sha256sum requirements.txt | cut -d' ' -f1)
-    HASH_FILE=".venv/requirements.sha256"
+    HASH_FILE="$VENV_DIR/requirements.sha256"
 
     REINSTALL=false
     if [ ! -f "$HASH_FILE" ]; then

--- a/Dockerfile/python/3.11-slim/entrypoint.sh
+++ b/Dockerfile/python/3.11-slim/entrypoint.sh
@@ -4,15 +4,19 @@ set -euo pipefail
 if [ -f "requirements.txt" ]; then
     echo "Initializing Python environment..."
 
-    if [ ! -d ".venv" ]; then
-        echo "Creating virtual environment..."
-        python3 -m venv .venv || { echo "Failed to create virtual environment"; exit 1; }
+    # Get Python version for venv directory naming
+    PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')")
+    VENV_DIR=".venv-${PYTHON_VERSION}"
+
+    if [ ! -d "$VENV_DIR" ]; then
+        echo "Creating virtual environment for Python ${PYTHON_VERSION}..."
+        python3 -m venv "$VENV_DIR" || { echo "Failed to create virtual environment"; exit 1; }
     fi
 
-    . .venv/bin/activate || { echo "Failed to activate virtual environment"; exit 1; }
+    . "$VENV_DIR/bin/activate" || { echo "Failed to activate virtual environment"; exit 1; }
 
     CURRENT_HASH=$(sha256sum requirements.txt | cut -d' ' -f1)
-    HASH_FILE=".venv/requirements.sha256"
+    HASH_FILE="$VENV_DIR/requirements.sha256"
 
     REINSTALL=false
     if [ ! -f "$HASH_FILE" ]; then

--- a/Dockerfile/python/3.12-slim/entrypoint.sh
+++ b/Dockerfile/python/3.12-slim/entrypoint.sh
@@ -4,15 +4,19 @@ set -euo pipefail
 if [ -f "requirements.txt" ]; then
     echo "Initializing Python environment..."
 
-    if [ ! -d ".venv" ]; then
-        echo "Creating virtual environment..."
-        python3 -m venv .venv || { echo "Failed to create virtual environment"; exit 1; }
+    # Get Python version for venv directory naming
+    PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')")
+    VENV_DIR=".venv-${PYTHON_VERSION}"
+
+    if [ ! -d "$VENV_DIR" ]; then
+        echo "Creating virtual environment for Python ${PYTHON_VERSION}..."
+        python3 -m venv "$VENV_DIR" || { echo "Failed to create virtual environment"; exit 1; }
     fi
 
-    . .venv/bin/activate || { echo "Failed to activate virtual environment"; exit 1; }
+    . "$VENV_DIR/bin/activate" || { echo "Failed to activate virtual environment"; exit 1; }
 
     CURRENT_HASH=$(sha256sum requirements.txt | cut -d' ' -f1)
-    HASH_FILE=".venv/requirements.sha256"
+    HASH_FILE="$VENV_DIR/requirements.sha256"
 
     REINSTALL=false
     if [ ! -f "$HASH_FILE" ]; then

--- a/Dockerfile/python/3.13-slim/entrypoint.sh
+++ b/Dockerfile/python/3.13-slim/entrypoint.sh
@@ -4,15 +4,19 @@ set -euo pipefail
 if [ -f "requirements.txt" ]; then
     echo "Initializing Python environment..."
 
-    if [ ! -d ".venv" ]; then
-        echo "Creating virtual environment..."
-        python3 -m venv .venv || { echo "Failed to create virtual environment"; exit 1; }
+    # Get Python version for venv directory naming
+    PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')")
+    VENV_DIR=".venv-${PYTHON_VERSION}"
+
+    if [ ! -d "$VENV_DIR" ]; then
+        echo "Creating virtual environment for Python ${PYTHON_VERSION}..."
+        python3 -m venv "$VENV_DIR" || { echo "Failed to create virtual environment"; exit 1; }
     fi
 
-    . .venv/bin/activate || { echo "Failed to activate virtual environment"; exit 1; }
+    . "$VENV_DIR/bin/activate" || { echo "Failed to activate virtual environment"; exit 1; }
 
     CURRENT_HASH=$(sha256sum requirements.txt | cut -d' ' -f1)
-    HASH_FILE=".venv/requirements.sha256"
+    HASH_FILE="$VENV_DIR/requirements.sha256"
 
     REINSTALL=false
     if [ ! -f "$HASH_FILE" ]; then

--- a/Dockerfile/python/3.14-slim/entrypoint.sh
+++ b/Dockerfile/python/3.14-slim/entrypoint.sh
@@ -4,15 +4,19 @@ set -euo pipefail
 if [ -f "requirements.txt" ]; then
     echo "Initializing Python environment..."
 
-    if [ ! -d ".venv" ]; then
-        echo "Creating virtual environment..."
-        python3 -m venv .venv || { echo "Failed to create virtual environment"; exit 1; }
+    # Get Python version for venv directory naming
+    PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')")
+    VENV_DIR=".venv-${PYTHON_VERSION}"
+
+    if [ ! -d "$VENV_DIR" ]; then
+        echo "Creating virtual environment for Python ${PYTHON_VERSION}..."
+        python3 -m venv "$VENV_DIR" || { echo "Failed to create virtual environment"; exit 1; }
     fi
 
-    . .venv/bin/activate || { echo "Failed to activate virtual environment"; exit 1; }
+    . "$VENV_DIR/bin/activate" || { echo "Failed to activate virtual environment"; exit 1; }
 
     CURRENT_HASH=$(sha256sum requirements.txt | cut -d' ' -f1)
-    HASH_FILE=".venv/requirements.sha256"
+    HASH_FILE="$VENV_DIR/requirements.sha256"
 
     REINSTALL=false
     if [ ! -f "$HASH_FILE" ]; then

--- a/Dockerfile/python/latest/entrypoint.sh
+++ b/Dockerfile/python/latest/entrypoint.sh
@@ -4,15 +4,19 @@ set -euo pipefail
 if [ -f "requirements.txt" ]; then
     echo "Initializing Python environment..."
 
-    if [ ! -d ".venv" ]; then
-        echo "Creating virtual environment..."
-        python3 -m venv .venv || { echo "Failed to create virtual environment"; exit 1; }
+    # Get Python version for venv directory naming
+    PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')")
+    VENV_DIR=".venv-${PYTHON_VERSION}"
+
+    if [ ! -d "$VENV_DIR" ]; then
+        echo "Creating virtual environment for Python ${PYTHON_VERSION}..."
+        python3 -m venv "$VENV_DIR" || { echo "Failed to create virtual environment"; exit 1; }
     fi
 
-    . .venv/bin/activate || { echo "Failed to activate virtual environment"; exit 1; }
+    . "$VENV_DIR/bin/activate" || { echo "Failed to activate virtual environment"; exit 1; }
 
     CURRENT_HASH=$(sha256sum requirements.txt | cut -d' ' -f1)
-    HASH_FILE=".venv/requirements.sha256"
+    HASH_FILE="$VENV_DIR/requirements.sha256"
 
     REINSTALL=false
     if [ ! -f "$HASH_FILE" ]; then


### PR DESCRIPTION
- fix: create/activate versioned venv (.venv-<python_version>) and store requirements hash alongside to avoid breakage after Python upgrades (update entrypoint.sh for 3.10–3.14 and latest)